### PR TITLE
Fix bug with with the fixed option for --order-type

### DIFF
--- a/OptiVac.py
+++ b/OptiVac.py
@@ -231,6 +231,9 @@ arising neo-epitopes is reduced. """)
             random.shuffle(peptides)
         else:
             print "Generating a fixed ordered polypeptide"
+            # peptides are added to the front of the list. So basically the
+            # original order can be retrieve by reversing this list.
+            peptides.reverse()
 
         order_sob = []
         for i in range(len(peptides)):

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ repository. This includes:
     random order of peptides in the string-of-breads, but still use the optimal
     spacers. Similarily for the fixed option, the order of the epitopes in the
     `--input` file is perserved, but optimal spacers are used.
-    + The changes can be found in the `feature/add-fixed-order` branch.
+    + The changes can be found in the `feature/add-fixed-order` and 
+        `bugfix/fixed-order` branches.
 
 **The individual feature branches will remain in case there is an opportunity
 in the future to merge these changes back to the original OptiVac repository.**


### PR DESCRIPTION
This PR fixes a bug with the fixed option for `--order-type` argument. The peptide order list is the reverse of the `--input` due to the way it is read. To get the original order, we use `peptides.reverse()`.