### PR TITLE
Switch to Reading Peptide Data into a List Rather than Set

### DIFF
--- a/OptiVac.py
+++ b/OptiVac.py
@@ -188,8 +188,21 @@ arising neo-epitopes is reduced. """)
 
     args = parser.parse_args()
 
-    #parse input
-    peptides = list(FileReader.read_lines(args.input, in_type=Peptide))
+    # Load the peptide data.
+    #
+    # Previously, the loading of these data was done using the
+    # `FileReader.read_lines() method`. But this uses a set to store the
+    # peptide data and this doesn't preserve the order the peptide data is
+    # loaded (i.e. added to the set). The order is important for the
+    # `--order-type fixed` option to work properly.
+    #
+    # This alternative implementation uses a list to store the data, which
+    # preserves the order that the peptide data is loaded.
+    peptides = []
+    with open(args.input, "r") as f:
+        for line in f:
+            peptides.append(Peptide(line.rstrip().upper()))
+
     #read in alleles
     alleles = generate_alleles(args.alleles)
 
@@ -231,9 +244,6 @@ arising neo-epitopes is reduced. """)
             random.shuffle(peptides)
         else:
             print "Generating a fixed ordered polypeptide"
-            # peptides are added to the front of the list. So basically the
-            # original order can be retrieve by reversing this list.
-            peptides.reverse()
 
         order_sob = []
         for i in range(len(peptides)):
@@ -254,6 +264,8 @@ arising neo-epitopes is reduced. """)
             ])
 
         svbws = order_sob
+    else:
+        print "Generating an optimally ordered polypeptide"
 
     print
     print "Resulting String-of-Beads: ","-".join(map(str,svbws))

--- a/OptiVac.py
+++ b/OptiVac.py
@@ -191,7 +191,7 @@ arising neo-epitopes is reduced. """)
     # Load the peptide data.
     #
     # Previously, the loading of these data was done using the
-    # `FileReader.read_lines() method`. But this uses a set to store the
+    # `FileReader.read_lines()` method. But this uses a set to store the
     # peptide data and this doesn't preserve the order the peptide data is
     # loaded (i.e. added to the set). The order is important for the
     # `--order-type fixed` option to work properly.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,3 @@
-#OptiVac - Designing String-of-beads with optimal spacers
-
-Authors: Benjamin Schubert and Oliver Kohlbacher   
-Date: June 2015   
-Version: 1.1  
-License: This software is under a three-clause BSD license  
-
-
-Introduction:
--------------
-
 This is a fork of the original OptiVac git repository
 (https://github.com/FRED-2/OptiVac). The original repository no longer appears
 to be under active development. As such, novel features have been added to this
@@ -22,11 +11,23 @@ repository. This includes:
     random order of peptides in the string-of-breads, but still use the optimal
     spacers. Similarily for the fixed option, the order of the epitopes in the
     `--input` file is perserved, but optimal spacers are used.
-    + The changes can be found in the `feature/add-fixed-order` and 
-        `bugfix/fixed-order` branches.
+    + The changes can be found in the `feature/add-fixed-order`, 
+        `bugfix/fixed-order`, and `bugfix/fixed-order-2` branches.
 
 **The individual feature branches will remain in case there is an opportunity
 in the future to merge these changes back to the original OptiVac repository.**
+
+# OptiVac - Designing String-of-beads with optimal spacers
+
+Authors: Benjamin Schubert and Oliver Kohlbacher   
+Date: June 2015   
+Version: 1.1  
+License: This software is under a three-clause BSD license  
+
+
+Introduction:
+-------------
+
 
 The software is a novel approach to construct epitope-based string-of-beads
 vaccines in optimal order and with sequence-optimized spacers of flexible length


### PR DESCRIPTION
The peptide data is loaded using the `FileReader.read_lines()` method. But this uses a set to store the peptide data and this doesn't preserve the order the peptide data is loaded (i.e. added to the set). The order is important for the `--order-type` fixed option to work properly.

This PR swaps out the `FileReader.read_lines()` method for a more basic reading. Most importantly it stores the `Peptide` objects into a list, which preserves the order the peptides are read in.